### PR TITLE
Added missing 'request' module to the dependencies. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "connect_router": "~1.8.7",
     "passport": "~0.1.17",
     "passport-oauth": "~1.0.0",
-    "passport-ldsauth": "~0.9.0"
+    "passport-ldsauth": "~0.9.0",
+    "request": "~2.55.0"
   }
 }


### PR DESCRIPTION
Added missing 'request' module to the dependencies. This fixes the error which is showed when you try to access the protected resource.
